### PR TITLE
Do not fetch past proposals by ids if there are empty

### DIFF
--- a/src/governance/snapshot/snapshot.graphql.service.ts
+++ b/src/governance/snapshot/snapshot.graphql.service.ts
@@ -38,6 +38,7 @@ export class SnapshotGraphqlService extends GraphqlService {
   }
 
   async getPastProposalsByIds(ids: string[]) {
+    if (ids.length === 0) return [];
     return this.getProposals(`id_in: ${JSON.stringify(ids)}`);
   }
 

--- a/src/governance/snapshot/snapshot.service.ts
+++ b/src/governance/snapshot/snapshot.service.ts
@@ -6,7 +6,7 @@ import {
 import { formatDate, VoteEntity, VoteSources } from '../vote.entity';
 import { proposalStateToVoteStatus, uniqueProposals } from './snapshot.helpers';
 
-const MAX_PAST_DAYS_PROPOSALS_FETCH = 30;
+const MAX_PAST_DAYS_PROPOSALS_FETCH = 14;
 
 @Injectable()
 export class SnapshotService {


### PR DESCRIPTION
Graphql returns some first 20 records if where condition like `id_in: []`
Reduce max past days to fetch back to two weeks