### PR TITLE
Update database schema if it differs from expected

### DIFF
--- a/src/governance/notionReporter/notion.record.entity.ts
+++ b/src/governance/notionReporter/notion.record.entity.ts
@@ -49,8 +49,9 @@ export class NotionTypes {
   };
 }
 
-class NotionEntity {
+export class NotionEntity {
   public static readonly propertiesNames;
+  constructor(private _: any) {}
   public static schema() {
     return Object.fromEntries(
       Object.keys(this.propertiesNames).map((key) => [
@@ -58,6 +59,9 @@ class NotionEntity {
         this.propertiesNames[key].schema,
       ]),
     );
+  }
+  properties() {
+    return {};
   }
 }
 
@@ -83,7 +87,7 @@ export class NotionVoteEntity extends NotionEntity {
     'Voters number': NotionTypes.number,
   };
   constructor(private vote: VoteEntity) {
-    super();
+    super(vote);
   }
 
   properties() {
@@ -139,7 +143,7 @@ export class NotionTopicEntity extends NotionEntity {
   };
 
   constructor(private topic: TopicEntity) {
-    super();
+    super(topic);
   }
 
   properties() {

--- a/src/governance/notionReporter/notion.reporter.service.ts
+++ b/src/governance/notionReporter/notion.reporter.service.ts
@@ -3,6 +3,7 @@ import { ConfigService } from '../../common/config';
 import { VoteEntity } from '../vote.entity';
 import {
   isValidProperties,
+  NotionEntity,
   NotionTopicEntity,
   NotionVoteEntity,
   topicFromNotionProperties,
@@ -98,24 +99,20 @@ export class NotionReporterService {
 
   async getVoteRecords(): Promise<SourceAndNameToVotePage> {
     const records: SourceAndNameToVotePage = {};
+    const synced = await this.syncDatabaseSchema(
+      this.votesDatabaseId,
+      NotionVoteEntity,
+    );
+    if (synced && this.configService.isDryRun()) return records;
     for await (const item of this.notion.queryDatabase(this.votesDatabaseId)) {
       if ('properties' in item) {
-        if (
-          !isValidProperties(NotionVoteEntity.propertiesNames, item.properties)
-        ) {
-          if (this.configService.isDryRun()) return records;
-          await this.updateProperties(
-            this.votesDatabaseId,
-            NotionVoteEntity.schema(),
-          );
-          this.logger.debug('Vote properties updating');
-        }
         const source =
           item.properties.Source.type === 'select' &&
-          item.properties.Source.select.name;
+          item.properties.Source.select?.name;
         const name =
           item.properties.Name.type === 'title' &&
-          item.properties.Name.title[0].plain_text;
+          item.properties.Name.title[0]?.plain_text;
+        if (!source || !name) continue;
         records[`${source}|${name}`] = {
           pageId: item.id,
           vote: voteFromNotionProperties(item.properties),
@@ -127,20 +124,16 @@ export class NotionReporterService {
 
   async getTopicRecords(): Promise<LinkToTopicPage> {
     const records: LinkToTopicPage = {};
+    const synced = await this.syncDatabaseSchema(
+      this.topicsDatabaseId,
+      NotionTopicEntity,
+    );
+    if (synced && this.configService.isDryRun()) return records;
     for await (const item of this.notion.queryDatabase(this.topicsDatabaseId)) {
       if ('properties' in item) {
-        if (
-          !isValidProperties(NotionTopicEntity.propertiesNames, item.properties)
-        ) {
-          this.logger.debug('Topic properties updating');
-          if (this.configService.isDryRun()) return records;
-          await this.updateProperties(
-            this.topicsDatabaseId,
-            NotionTopicEntity.schema(),
-          );
-        }
         const id =
-          item.properties.ID.type === 'number' && item.properties.ID.number;
+          item.properties.ID?.type === 'number' && item.properties.ID.number;
+        if (!id) continue;
         records[id] = {
           pageId: item.id,
           topic: topicFromNotionProperties(item.properties),
@@ -150,10 +143,25 @@ export class NotionReporterService {
     return records;
   }
 
-  async updateProperties(databaseId, schema): Promise<void> {
-    await this.notion.databases.update({
+  async syncDatabaseSchema(
+    databaseId,
+    entity: typeof NotionEntity,
+  ): Promise<boolean> {
+    const database = await this.notion.databases.retrieve({
       database_id: databaseId,
-      properties: schema,
     });
+    if (!isValidProperties(entity.propertiesNames, database.properties)) {
+      if (!this.configService.isDryRun())
+        await this.notion.databases.update({
+          database_id: databaseId,
+          properties: entity.schema(),
+        });
+      this.logger.log(
+        `${this.configService.isDryRun() ? '[Dry Run] ' : ''}` +
+          `Updated ${entity.name} database schema`,
+      );
+      return true;
+    }
+    return false;
   }
 }


### PR DESCRIPTION
- store database schema in entities
- sync database schema before fetching and updating items
- now reporting works even if database is empty and has no required fields
- additional database fields (not in schema) remain as is
- if dry run enabled log if schema update required